### PR TITLE
DEPLOY-350 Remove minor release from CentOS in tag

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -1,4 +1,4 @@
 DOCKER_IMAGE_REPOSITORY=alfresco-base-java
-DOCKER_IMAGE_TAG=8u161-oracle-centos-7.4
+DOCKER_IMAGE_TAG=8u161-oracle-centos-7
 JRE_URL=http://download.oracle.com/otn-pub/java/jdk/8u161-b12/2f38c3b165be4555a1fa6e98c45e0808/server-jre-8u161-linux-x64.tar.gz
 JRE_CHECKSUM_256=eb5776cacfd57fbf0ffb907f68c58a1cc6f823e761f4e75d78a6e3240846534e


### PR DESCRIPTION
As agreed, CentOS minor versions are irrelevant to (sys)admins.