### PR TITLE
DEPLOY-395 Override CentOS labels

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,11 @@
 # This is an initial iteration and subject to change
 FROM centos:7.4.1708
 
+LABEL name="Alfresco Base Java" \
+    vendor="Alfresco" \
+    license="Various" \
+    build-date="unset"
+
 RUN yum -y update nss bind-license curl systemd
 # Added curl update to fix security issue, this should be removed on next iteration if not necessary
 ENV JAVA_PKG=serverjre-*.tar.gz \


### PR DESCRIPTION
The base image has these four LABELs set. You cannot remove labels, but you can overwrite them. We can consider making `license` and `build-date` more meaningful at some time in the future.