### PR TITLE
MNT-21726: Tomcat 8.5.43 delivered with latest ACS installers is vulnerable to CVE-2020-1938

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,7 @@ RUN yum -y update \
     bind-license-9.11.4-16.P2.el7_8.6 \
     elfutils-libs-0.176-4.el7 \
     file-libs-5.11-36.el7 \
+    dbus-1.10.24-14.el7_8 \
     elfutils-default-yama-scope-0.176-4.el7 \
     && \
     yum clean all


### PR DESCRIPTION
- Replace vulnerable `dbus` (which also brings `dbus-libs`) library with a fixed version for [CVE-2020-12049](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-12049)