### PR TITLE
ACS-1210 cleanup support CentOS 7 and 8

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,4 +9,3 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
-

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,4 +9,4 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
-    target-branch: "ACS-1210"
+

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,4 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
+    target-branch: "ACS-1210"

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,17 +8,17 @@ branches:
     - master
 
 env:
-  - CENTOS_MAJOR_VERSION=7 JAVA_MAJOR_VERSION=8
-  - CENTOS_MAJOR_VERSION=7 JAVA_MAJOR_VERSION=11
-  - CENTOS_MAJOR_VERSION=8 JAVA_MAJOR_VERSION=8
-  - CENTOS_MAJOR_VERSION=8 JAVA_MAJOR_VERSION=11
+  - CENTOS_MAJOR=7 JAVA_MAJOR=8
+  - CENTOS_MAJOR=7 JAVA_MAJOR=11
+  - CENTOS_MAJOR=8 JAVA_MAJOR=8
+  - CENTOS_MAJOR=8 JAVA_MAJOR=11
 
 before_script:
   - export BRANCH=${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}
   - echo $QUAY_PASSWORD | docker login quay.io -u $QUAY_USERNAME --password-stdin
   - echo $DOCKER_PASSWORD | docker login docker.io -u "$DOCKER_USERNAME" --password-stdin
   - |-
-    case $JAVA_MAJOR_VERSION in
+    case $JAVA_MAJOR in
       8)
         export JAVA_VERSION=8u202
         java_pkg_type=serverjre
@@ -39,7 +39,7 @@ before_script:
   - |-
     export IMAGE_REGISTRY_NAMESPACE=alfresco
     export IMAGE_REPOSITORY=alfresco-base-java
-    export IMAGE_TAG=$JAVA_VERSION-$JAVA_VENDOR-centos-$CENTOS_MAJOR_VERSION
+    export IMAGE_TAG=$JAVA_VERSION-$JAVA_VENDOR-centos-$CENTOS_MAJOR
 
 script:
   - |-
@@ -47,7 +47,7 @@ script:
 
     wget --user=$JAVA_URL_USERNAME --password=$JAVA_URL_PASSWORD $JAVA_URL
     docker build -t $IMAGE_REPOSITORY . \
-      --build-arg CENTOS_MAJOR_VERSION=$CENTOS_MAJOR_VERSION \
+      --build-arg CENTOS_MAJOR=$CENTOS_MAJOR \
       --build-arg JAVA_PKG=$JAVA_PKG \
       --build-arg BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
     [[ $BRANCH == master ]] && IMAGE_TAG_SUFFIX=release-candidate || IMAGE_TAG_SUFFIX=$BRANCH
@@ -63,7 +63,7 @@ script:
       for IMAGE_REGISTRY in quay.io docker.io
       do
         echo "tagging and pushing to $IMAGE_REGISTRY"
-        for TAG in $IMAGE_TAG $IMAGE_TAG-$SHORT_SHA256 $JAVA_MAJOR_VERSION
+        for TAG in $IMAGE_TAG $IMAGE_TAG-$SHORT_SHA256 $JAVA_MAJOR
         do
           docker tag $IMAGE_REPOSITORY $IMAGE_REGISTRY/$IMAGE_REGISTRY_NAMESPACE/$IMAGE_REPOSITORY:$TAG
           docker push $IMAGE_REGISTRY/$IMAGE_REGISTRY_NAMESPACE/$IMAGE_REPOSITORY:$TAG

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,15 +18,6 @@ before_script:
   - echo $QUAY_PASSWORD | docker login quay.io -u $QUAY_USERNAME --password-stdin
   - echo $DOCKER_PASSWORD | docker login docker.io -u "$DOCKER_USERNAME" --password-stdin
   - |-
-    case $CENTOS_MAJOR_VERSION in
-      7)
-        export CENTOS_VERSION=7.9.2009
-        ;;
-      8)
-        export CENTOS_VERSION=8.3.2011
-        ;;
-    esac
-  - |-
     case $JAVA_MAJOR_VERSION in
       8)
         export JAVA_VERSION=8u181
@@ -57,7 +48,6 @@ script:
     wget --user=$JAVA_URL_USERNAME --password=$JAVA_URL_PASSWORD $JAVA_URL
     docker build -t $IMAGE_REPOSITORY . \
       --build-arg CENTOS_MAJOR_VERSION=$CENTOS_MAJOR_VERSION \
-      --build-arg CENTOS_VERSION=$CENTOS_VERSION \
       --build-arg JAVA_PKG=$JAVA_PKG \
       --build-arg BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
     [[ $BRANCH == master ]] && IMAGE_TAG_SUFFIX=release-candidate || IMAGE_TAG_SUFFIX=$BRANCH

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,10 +20,10 @@ before_script:
   - |-
     case $JAVA_MAJOR_VERSION in
       8)
-        export JAVA_VERSION=8u181
+        export JAVA_VERSION=8u202
         java_pkg_type=serverjre
         export JAVA_VENDOR=oracle
-        export JAVA_PKG=${java_pkg_type}-${JAVA_VERSION}-bin.tar.gz
+        export JAVA_PKG=$java_pkg_type-$JAVA_VERSION-bin.tar.gz
         export JAVA_URL_USERNAME=$NEXUS_USERNAME
         export JAVA_URL_PASSWORD=$NEXUS_PASSWORD
         export JAVA_URL=https://artifacts.alfresco.com/nexus/content/repositories/oracle-java/linux-x64/$java_pkg_type/$JAVA_VERSION/$JAVA_PKG

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,28 @@
 # Alfresco Base Java Image
 
-ARG CENTOS_VERSION=7
-FROM centos:$CENTOS_VERSION
+ARG CENTOS_MAJOR_VERSION=7
+FROM centos:7.9.2009 AS centos-7
+RUN set -eux; \
+	deps=" \
+        openssl-libs-1.0.2k-21.el7_9 \
+        libcurl-7.29.0-59.el7_9.1 \
+        curl-7.29.0-59.el7_9.1 \
+        python-2.7.5-90.el7 \
+        python-libs-2.7.5-90.el7 \
+        bind-license-9.11.4-26.P2.el7_9.2 \
+	"; \
+    yum -y update $deps; \
+    yum clean all
+FROM centos:8.3.2011 AS centos-8
+RUN set -eux; \
+	deps=" \
+        openssl-libs-1.1.1g-12.el8_3 \
+        gnutls-3.6.14-7.el8_3 \
+	"; \
+    yum -y update $deps; \
+    yum clean all
+
+FROM centos-$CENTOS_MAJOR_VERSION
 
 LABEL org.label-schema.schema-version="1.0" \
     org.label-schema.name="Alfresco Base Java Image" \
@@ -10,24 +31,6 @@ LABEL org.label-schema.schema-version="1.0" \
     org.opencontainers.image.title="Alfresco Base Java Image" \
     org.opencontainers.image.vendor="Alfresco" \
     org.opencontainers.image.created="$BUILD_DATE"
-
-ARG CENTOS_MAJOR_VERSION=7
-
-ENV CENTOS_7_UPDATES \
-    openssl-libs-1.0.2k-21.el7_9 \
-    libcurl-7.29.0-59.el7_9.1 \
-    curl-7.29.0-59.el7_9.1 \
-    python-2.7.5-90.el7 \
-    python-libs-2.7.5-90.el7 \
-    bind-license-9.11.4-26.P2.el7_9.2
-
-ENV CENTOS_8_UPDATES \
-    openssl-libs-1.1.1g-12.el8_3 \
-    gnutls-3.6.14-7.el8_3
-
-RUN if [[ "$CENTOS_MAJOR_VERSION" == "7" ]] ; then CENTOS_UPDATES=$CENTOS_7_UPDATES;  fi && \
-    if [[ "$CENTOS_MAJOR_VERSION" == "8" ]] ; then CENTOS_UPDATES=$CENTOS_8_UPDATES;  fi && \
-    yum -y update $CENTOS_UPDATES && yum clean all
 
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Alfresco Base Java Image
 
-ARG CENTOS_MAJOR_VERSION=7
+ARG CENTOS_MAJOR=7
 FROM centos:7.8.2003 AS centos-7
 RUN set -eux; \
 	deps=" \
@@ -22,7 +22,7 @@ RUN set -eux; \
     yum -y update $deps; \
     yum clean all
 
-FROM centos-$CENTOS_MAJOR_VERSION
+FROM centos-$CENTOS_MAJOR
 ARG BUILD_DATE
 LABEL org.label-schema.schema-version="1.0" \
     org.label-schema.name="Alfresco Base Java Image" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Alfresco Base Java Image
 
 ARG CENTOS_MAJOR_VERSION=7
-FROM centos:7.9.2009 AS centos-7
+FROM centos:7.8.2003 AS centos-7
 RUN set -eux; \
 	deps=" \
         openssl-libs-1.0.2k-21.el7_9 \
@@ -13,7 +13,7 @@ RUN set -eux; \
 	"; \
     yum -y update $deps; \
     yum clean all
-FROM centos:8.3.2011 AS centos-8
+FROM centos:8.2.2004 AS centos-8
 RUN set -eux; \
 	deps=" \
         openssl-libs-1.1.1g-12.el8_3 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN set -eux; \
     yum clean all
 
 FROM centos-$CENTOS_MAJOR_VERSION
-
+ARG BUILD_DATE
 LABEL org.label-schema.schema-version="1.0" \
     org.label-schema.name="Alfresco Base Java Image" \
     org.label-schema.vendor="Alfresco" \

--- a/README.md
+++ b/README.md
@@ -4,22 +4,21 @@
 
 ## Introduction
 
-This repository contains the [Dockerfile](Dockerfile) used to create the base Java image that
-will be used by Alfresco engineering teams, other internal groups in the
-organisation, customers and partners to create images as part of the Alfresco
-Digital Business Platform.
-
-The architectural decision record can be found [![here](https://img.shields.io/badge/Anaxes%20ADR%205--green.svg?longCache=true&style=plastic)](https://github.com/Alfresco/alfresco-anaxes-shipyard/blob/master/docs/adrs/0005-base-java-docker-image-composition.md).
+This repository contains the [Dockerfile](Dockerfile) used to create the base Java image that will be used by Alfresco engineering teams,
+other internal groups in the organisation, customers and partners to create Java images from.
 
 ## Versioning
 
 ### Legacy Oracle Java 8
 
-For legacy Oracle Java 8 builds, the serverjre has been saved in Alfresco's artifact repository, last version is 8u181.
+For legacy Oracle Java 8 builds, version 8u202 of the serverjre has been saved in Alfresco artifact repository,
+which is the last one available with the BCL license.
 
 ### OpenJDK Java 11
 
-For OpenJDK builds from Java 11, the binary is downloaded from [AdoptOpenJDK](https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries).
+For OpenJDK builds from Java 11.0.10, the most updated binary is downloaded from [AdoptOpenJDK](https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries).
+
+Options are available using CentOS 7 and 8 as base.
 
 Build-pinning is available on Quay and Docker Hub to ensure an exact build artifact is used.
 
@@ -31,8 +30,8 @@ To build a local version of the base java image follow the instructions below
 
 #### Download JDK
 
-Download any `tar.gz` of the serverjre or jdk into [.](.). Save the filename in
-a variable. e.g.
+Download any `tar.gz` of the jdk into [.](.).
+Save the filename in a variable. e.g.
 
 ```bash
 export java_filename='jdk-11_linux-x64_bin.tar.gz'
@@ -55,27 +54,32 @@ Just push a commit on the default branch including `'[release]` in the message t
 Builds are available from [Docker Hub](https://hub.docker.com/r/alfresco/alfresco-base-java):
 
 ```bash
-docker pull alfresco/alfresco-base-java:8
-docker pull alfresco/alfresco-base-java:8u161-oracle-centos-7
-docker pull alfresco/alfresco-base-java:8u161-oracle-centos-7-333472fed423
+docker pull alfresco/alfresco-base-java:$JAVA_MAJOR_VERSION
+docker pull alfresco/alfresco-base-java:$JAVA_VERSION-$JAVA_VENDOR-centos-$CENTOS_MAJOR_VERSION
+docker pull alfresco/alfresco-base-java:$JAVA_VERSION-$JAVA_VENDOR-centos-$CENTOS_MAJOR_VERSION-$SHORT_SHA256
 ```
 
-The builds are identical to those stored in the private repo on Quay,
-(which also supports build-pinning versions).
+where:
+* JAVA_MAJOR_VERSION is 8 or 11
+* JAVA_VERSION is 8u202 or 11.0.10
+* JAVA_VENDOR is `oracle` for 8 and `openjdk` for 11
+* CENTOS_MAJOR_VERSION is 7 or 8
+* SHORT_SHA256 is the 12 digit SHA256 of the image as available from the registry
+
+The builds are identical to those stored in the private repo on Quay, which also supports build-pinning versions.
 
 ```bash
-docker pull quay.io/alfresco/alfresco-base-java:8
-docker pull quay.io/alfresco/alfresco-base-java:8u161-oracle-centos-7
-docker pull quay.io/alfresco/alfresco-base-java:8u161-oracle-centos-7-333472fed423
+docker pull quay.io/alfresco/alfresco-base-java:$JAVA_MAJOR_VERSION
+docker pull quay.io/alfresco/alfresco-base-java:$JAVA_VERSION-$JAVA_VENDOR-centos-$CENTOS_MAJOR_VERSION
+docker pull quay.io/alfresco/alfresco-base-java:$JAVA_VERSION-$JAVA_VENDOR-centos-$CENTOS_MAJOR_VERSION-$SHORT_SHA256
 ```
 
 ## Usage
 
 ### Standalone
 
-The image can be used via `docker run` to run java applications
-with `--read-only` set, without any loss of functionality (with the
-obvious caveat that the application itself does not write to the filesystem).
+The image can be used via `docker run` to run java applications with `--read-only` set,
+without any loss of functionality (with the obvious caveat that the application itself does not write to the filesystem).
 
 ### Base Image
 
@@ -89,13 +93,13 @@ instruction, and [best practices with VOLUMEs](https://docs.docker.com/develop/d
 Example from a Dockerfile using a public base image in Docker Hub.
 
 ```bash
-FROM alfresco/alfresco-base-java:8
+FROM alfresco/alfresco-base-java:11
 ```
 
 Example from a Dockerfile using a private base image in Quay:
 
 ```bash
-FROM quay.io/alfresco/alfresco-base-java:8u161-oracle-centos-7-333472fed423
+FROM quay.io/alfresco/alfresco-base-java:11.0.10-oracle-centos-7-fc1ad2925112
 ```
 
 See [Alfresco Base Tomcat](https://github.com/Alfresco/alfresco-docker-base-tomcat/blob/master/Dockerfile) for a concrete example.

--- a/README.md
+++ b/README.md
@@ -54,24 +54,24 @@ Just push a commit on the default branch including `'[release]` in the message t
 Builds are available from [Docker Hub](https://hub.docker.com/r/alfresco/alfresco-base-java):
 
 ```bash
-docker pull alfresco/alfresco-base-java:$JAVA_MAJOR_VERSION
-docker pull alfresco/alfresco-base-java:$JAVA_VERSION-$JAVA_VENDOR-centos-$CENTOS_MAJOR_VERSION
-docker pull alfresco/alfresco-base-java:$JAVA_VERSION-$JAVA_VENDOR-centos-$CENTOS_MAJOR_VERSION-$SHORT_SHA256
+docker pull alfresco/alfresco-base-java:$JAVA_MAJOR
+docker pull alfresco/alfresco-base-java:$JAVA_VERSION-$JAVA_VENDOR-centos-$CENTOS_MAJOR
+docker pull alfresco/alfresco-base-java:$JAVA_VERSION-$JAVA_VENDOR-centos-$CENTOS_MAJOR-$SHORT_SHA256
 ```
 
 where:
-* JAVA_MAJOR_VERSION is 8 or 11
+* JAVA_MAJOR is 8 or 11
 * JAVA_VERSION is 8u202 or 11.0.10
 * JAVA_VENDOR is `oracle` for 8 and `openjdk` for 11
-* CENTOS_MAJOR_VERSION is 7 or 8
+* CENTOS_MAJOR is 7 or 8
 * SHORT_SHA256 is the 12 digit SHA256 of the image as available from the registry
 
 The builds are identical to those stored in the private repo on Quay, which also supports build-pinning versions.
 
 ```bash
-docker pull quay.io/alfresco/alfresco-base-java:$JAVA_MAJOR_VERSION
-docker pull quay.io/alfresco/alfresco-base-java:$JAVA_VERSION-$JAVA_VENDOR-centos-$CENTOS_MAJOR_VERSION
-docker pull quay.io/alfresco/alfresco-base-java:$JAVA_VERSION-$JAVA_VENDOR-centos-$CENTOS_MAJOR_VERSION-$SHORT_SHA256
+docker pull quay.io/alfresco/alfresco-base-java:$JAVA_MAJOR
+docker pull quay.io/alfresco/alfresco-base-java:$JAVA_VERSION-$JAVA_VENDOR-centos-$CENTOS_MAJOR
+docker pull quay.io/alfresco/alfresco-base-java:$JAVA_VERSION-$JAVA_VENDOR-centos-$CENTOS_MAJOR-$SHORT_SHA256
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Introduction
 
-This repository contains the [Dockerfile](Dockerfile) used to create the parent Java image that
+This repository contains the [Dockerfile](Dockerfile) used to create the base Java image that
 will be used by Alfresco engineering teams, other internal groups in the
 organisation, customers and partners to create images as part of the Alfresco
 Digital Business Platform.
@@ -79,20 +79,20 @@ obvious caveat that the application itself does not write to the filesystem).
 
 ### Base Image
 
-It is more likely to be used as a [base image](https://docs.docker.com/glossary/?term=parent%20image#base-image) in a Dockerfile.
+It is more likely to be used as a [base image](https://docs.docker.com/glossary/#base-image) in a Dockerfile.
 For reference, see the documentation on [layers](https://docs.docker.com/storage/storagedriver/#container-and-layers),
 the [VOLUME](https://docs.docker.com/engine/reference/builder/#volume)
 instruction, and [best practices with VOLUMEs](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#volume).
 
-### Examples of usage as a parent image
+### Examples of usage as a base image
 
-Example from a Dockerfile using a public, parent image in Docker Hub.
+Example from a Dockerfile using a public base image in Docker Hub.
 
 ```bash
 FROM alfresco/alfresco-base-java:8
 ```
 
-Example from a Dockerfile using a private, parent image in Quay:
+Example from a Dockerfile using a private base image in Quay:
 
 ```bash
 FROM quay.io/alfresco/alfresco-base-java:8u161-oracle-centos-7-333472fed423

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Alfresco Docker Base Java
 
 [![Build Status](https://travis-ci.com/Alfresco/alfresco-docker-base-java.svg?branch=master)](https://travis-ci.com/Alfresco/alfresco-docker-base-java)
-[![Docker Repository on Quay](https://quay.io/repository/alfresco/alfresco-base-java/status?token=7b035610-24b5-4ed7-a95f-6e812628cd8e "Docker Repository on Quay")](https://quay.io/repository/alfresco/alfresco-base-java)
 
 ## Introduction
 


### PR DESCRIPTION
ACS-1210 cleanup and simplify CentOS 8 support and moved actual CentOS semver tags inside Dockerfile using a multi stage build to let dependabot kick in for CentOS image version updates 