### PR TITLE
ACS-1199 fix vuln on glibc

### DIFF
--- a/centos-7/Dockerfile
+++ b/centos-7/Dockerfile
@@ -8,6 +8,7 @@ RUN set -eux; \
         python-2.7.5-90.el7 \
         python-libs-2.7.5-90.el7 \
         bind-license-9.11.4-26.P2.el7_9.2 \
+        glibc-2.17-322.el7_9 \
 	"; \
     yum -y update $deps; \
     yum clean all


### PR DESCRIPTION
Reported by Quay:

* https://quay.io/repository/alfresco/alfresco-base-java/manifest/sha256:4b398c8cf3ae62bd5db61b6df222ae3c780101816742bc19d1d76732651abf86?tab=vulnerabilities
* https://quay.io/repository/alfresco/alfresco-base-java/manifest/sha256:165d90e65d51991380b8ac3bedc0661fc78d18bc05d11374336a1a967659a081?tab=vulnerabilities

Nothing reported by snyk on DockerHub

