### PR TITLE
DEVOPS-5 update vulnerabilties openssl, gnutls and nettle

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,13 +107,15 @@ FROM alfresco/alfresco-base-java:11
 Example from a Dockerfile using a private base image in Quay:
 
 ```bash
-FROM quay.io/alfresco/alfresco-base-java:11.0.10-openjdk-centos-7-954752c611bf
+FROM quay.io/alfresco/alfresco-base-java:11.0.10-openjdk-centos-7-$SHORT_SHA256
 ```
+where `SHORT_SHA256` is the 12-digit short sha256 image digest.
 
 or pinned:
 
 ```bash
-FROM quay.io/alfresco/alfresco-base-java:11.0.10-oracle-centos-7@sha256:954752c611bf52883a8519197a2ee29c8686b0bbd2cc48752cd740a864a6c233
+FROM quay.io/alfresco/alfresco-base-java:11.0.10-openjdk-centos-7@sha256:$SHA256
 ```
+where `SHA256` is the full sha256 image digest.
 
 See [Alfresco Base Tomcat](https://github.com/Alfresco/alfresco-docker-base-tomcat/blob/master/Dockerfile) for a concrete example.

--- a/centos-8/Dockerfile
+++ b/centos-8/Dockerfile
@@ -2,9 +2,11 @@
 FROM centos:8.3.2011
 RUN set -eux; \
 	deps=" \
-        openssl-libs-1.1.1g-12.el8_3 \
-        gnutls-3.6.14-7.el8_3 \
+        openssl-1.1.1g-15.el8_3 \
+        openssl-libs-1.1.1g-15.el8_3 \
+        gnutls-3.6.14-8.el8_3 \
         bind-export-libs-9.11.20-5.el8_3.1 \
+        nettle-3.4.1-2.el8 \
 	"; \
     yum -y update $deps; \
     yum clean all

--- a/centos-8/Dockerfile
+++ b/centos-8/Dockerfile
@@ -6,7 +6,7 @@ RUN set -eux; \
         openssl-libs-1.1.1g-15.el8_3 \
         gnutls-3.6.14-8.el8_3 \
         bind-export-libs-9.11.20-5.el8_3.1 \
-        nettle-3.4.1-2.el8 \
+        nettle-3.4.1-4.el8_3 \
 	"; \
     yum -y update $deps; \
     yum clean all


### PR DESCRIPTION
Update reported vulnerabilities as in DEVOPS-5 