### PR TITLE
OPSEXP-1295: fix python-lxml vulnerability

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,11 +33,6 @@ jobs:
           - base_image:
               flavor: centos
               major: 7
-            java_major: 8
-            jdist: jdk
-          - base_image:
-              flavor: centos
-              major: 7
             java_major: 11
             jdist: jdk
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,10 +19,6 @@ jobs:
             major: 3.15
           - flavor: centos
             major: 7
-          - flavor: debian
-            major: 11
-          - flavor: ubuntu
-            major: 20.04
           - flavor: ubi
             major: 8
         java_major:

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,6 +57,9 @@ RUN yum update -y && \
     [ $JAVA_MAJOR -eq 8 ] && JAVA_PKG_VERSION='1.8.0'; \
     [ $JAVA_MAJOR -eq 11 ] && JAVA_PKG_VERSION='11'; \
     yum install -y java-${JAVA_PKG_VERSION}-openjdk-${PKG_DEVEL:-headless} && \
+    # iRemove vulnerable packages shipped with base image (space separated list)
+    PKG_4_REMOVAL="python-lxml" ; \
+    rpm -e --nodeps ${PKG_4_REMOVAL} && \
     yum clean all && \
     JAVA_BIN_PATH=$(rpm -ql java-${JAVA_PKG_VERSION}-openjdk-${PKG_DEVEL:-headless} | grep '\/bin\/java$') && \
     test -L $JAVA_HOME || ln -sf ${JAVA_BIN_PATH%*/bin/java} $JAVA_HOME

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,7 +57,7 @@ RUN yum update -y && \
     [ $JAVA_MAJOR -eq 8 ] && JAVA_PKG_VERSION='1.8.0'; \
     [ $JAVA_MAJOR -eq 11 ] && JAVA_PKG_VERSION='11'; \
     yum install -y java-${JAVA_PKG_VERSION}-openjdk-${PKG_DEVEL:-headless} && \
-    # iRemove vulnerable packages shipped with base image (space separated list)
+    # Remove vulnerable packages shipped with base image (space separated list)
     PKG_4_REMOVAL="python-lxml" ; \
     rpm -e --nodeps ${PKG_4_REMOVAL} && \
     yum clean all && \


### PR DESCRIPTION
removes the python-lxml package which triggers security scanner warnings (high a& medium) on quay.io.
Can potentially break some advanced yum tools but no other fix is available.