### PR TITLE
OPSEXP-1320 Add rockylinux flavour

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,6 +21,8 @@ jobs:
             major: 7
           - flavor: ubi
             major: 8
+          - flavor: rockylinux
+            major: 8
         java_major:
           - 11
         jdist:
@@ -29,6 +31,11 @@ jobs:
           - base_image:
               flavor: centos
               major: 7
+            java_major: 11
+            jdist: jdk
+          - base_image:
+              flavor: rockylinux
+              major: 8
             java_major: 11
             jdist: jdk
     runs-on: ubuntu-latest


### PR DESCRIPTION
* add Rocky Linux 8 as successor of CentOS 8
* pin UBI image
* publish JDK for both CentOS 8 and Rocky Linux 8