### PR TITLE
Dependabot should ignore rockylinux major versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,6 @@ updates:
         versions:
           - ">= 8"
           - "<7"
+    ignore:
+      - dependency-name: "rockylinux"
+        update-types: ["version-update:semver-major"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,5 @@ updates:
         versions:
           - ">= 8"
           - "<7"
-    ignore:
       - dependency-name: "rockylinux"
         update-types: ["version-update:semver-major"]


### PR DESCRIPTION
we don't want https://github.com/Alfresco/alfresco-docker-base-java/pull/113