### PR TITLE
OPSEXP-1737: rocky jdk update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ RUN set -eux; \
   fi && \
   yum clean all && rm -rf /var/cache/yum
 
-FROM rockylinux:8.6.20227707@sha256:afd392a691df0475390df77cb5486f226bc2b4cbaf87c41785115b9237f3203f AS rockylinux8
+FROM rockylinux:8.6.20227707 AS rockylinux8
 
 ARG JDIST
 ARG JAVA_MAJOR


### PR DESCRIPTION
Ref: OPSEXP-1737

Mainly provide a fix for ACS-3565