### PR TITLE
OPSEXP-2432 Disable automated dependabot for Docker

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,8 +9,3 @@ updates:
     directory: /
     schedule:
       interval: weekly
-
-  - package-ecosystem: docker
-    directory: /
-    schedule:
-      interval: weekly


### PR DESCRIPTION
We are sticking manually to the Alfresco supported platforms as per https://docs.alfresco.com/content-services/latest/support/