### PR TITLE
OPSEXP-2949 Update readme with JRE 21 image and remove build for rockylinux8 with JRE21

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,6 +40,10 @@ jobs:
               flavor: rockylinux
               major: 9
             java_major: 11
+          - base_image:
+              flavor: rockylinux
+              major: 8
+            java_major: 21
     steps:
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
 

--- a/README.md
+++ b/README.md
@@ -13,14 +13,12 @@ Java version | Java flavour | OS            | Image ref                         
 17           | jre          | Rocky Linux 8 | `alfresco/alfresco-base-java:jre17-rockylinux8` | ![jre17-rockylinux8 size][1]
 11           | jre          | Rocky Linux 8 | `alfresco/alfresco-base-java:jre11-rockylinux8` | ![jre11-rockylinux8 size][2]
 17           | jre          | Rocky Linux 9 | `alfresco/alfresco-base-java:jre17-rockylinux9` | ![jre17-rockylinux9 size][3]
-21           | jre          | Rocky Linux 8 | `alfresco/alfresco-base-java:jre21-rockylinux8` | ![jre21-rockylinux8 size][4]
-21           | jre          | Rocky Linux 9 | `alfresco/alfresco-base-java:jre21-rockylinux9` | ![jre21-rockylinux9 size][5]
+21           | jre          | Rocky Linux 9 | `alfresco/alfresco-base-java:jre21-rockylinux9` | ![jre21-rockylinux9 size][4]
 
 [1]: https://img.shields.io/docker/image-size/alfresco/alfresco-base-java/jre17-rockylinux8
 [2]: https://img.shields.io/docker/image-size/alfresco/alfresco-base-java/jre11-rockylinux8
 [3]: https://img.shields.io/docker/image-size/alfresco/alfresco-base-java/jre17-rockylinux9
-[4]: https://img.shields.io/docker/image-size/alfresco/alfresco-base-java/jre21-rockylinux8
-[5]: https://img.shields.io/docker/image-size/alfresco/alfresco-base-java/jre21-rockylinux9
+[4]: https://img.shields.io/docker/image-size/alfresco/alfresco-base-java/jre21-rockylinux9
 
 The images are available on:
 

--- a/README.md
+++ b/README.md
@@ -13,10 +13,14 @@ Java version | Java flavour | OS            | Image ref                         
 17           | jre          | Rocky Linux 8 | `alfresco/alfresco-base-java:jre17-rockylinux8` | ![jre17-rockylinux8 size][1]
 11           | jre          | Rocky Linux 8 | `alfresco/alfresco-base-java:jre11-rockylinux8` | ![jre11-rockylinux8 size][2]
 17           | jre          | Rocky Linux 9 | `alfresco/alfresco-base-java:jre17-rockylinux9` | ![jre17-rockylinux9 size][3]
+21           | jre          | Rocky Linux 8 | `alfresco/alfresco-base-java:jre21-rockylinux8` | ![jre21-rockylinux8 size][4]
+21           | jre          | Rocky Linux 9 | `alfresco/alfresco-base-java:jre21-rockylinux9` | ![jre21-rockylinux9 size][5]
 
 [1]: https://img.shields.io/docker/image-size/alfresco/alfresco-base-java/jre17-rockylinux8
 [2]: https://img.shields.io/docker/image-size/alfresco/alfresco-base-java/jre11-rockylinux8
 [3]: https://img.shields.io/docker/image-size/alfresco/alfresco-base-java/jre17-rockylinux9
+[4]: https://img.shields.io/docker/image-size/alfresco/alfresco-base-java/jre21-rockylinux8
+[5]: https://img.shields.io/docker/image-size/alfresco/alfresco-base-java/jre21-rockylinux9
 
 The images are available on:
 


### PR DESCRIPTION
Ref: OPSEXP-2949 