### PR TITLE
OPSEXP-4054 Use minimal Rocky Linux tags in CI matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,11 +28,11 @@ jobs:
           - flavor: rockylinux
             major: 8
             image_name: rockylinux/rockylinux
-            image_tag: 8
+            image_tag: 8-minimal
           - flavor: rockylinux
             major: 9
             image_name: rockylinux/rockylinux
-            image_tag: 9
+            image_tag: 9-minimal
         java_major:
           - 11
           - 17


### PR DESCRIPTION
## Summary
Switch the Rocky Linux image tags in the workflow matrix from `8`/`9` to `8-minimal`/`9-minimal` while keeping the same image repository.

## Why
This aligns CI image selection with the minimal Rocky Linux variants required by OPSEXP-4054.

## Changes
- Update Rocky Linux 8 workflow matrix tag from `8` to `8-minimal`
- Update Rocky Linux 9 workflow matrix tag from `9` to `9-minimal`